### PR TITLE
Fix HTML injection on suspended page (#105)

### DIFF
--- a/src/main/discarded/Main.js
+++ b/src/main/discarded/Main.js
@@ -34,7 +34,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
   sessionStorage.setItem(hash, 'true');
   document.title = title + ' - discarded';
-  document.querySelector('#t').innerHTML = title;
+  const titleNode = document.querySelector('#t');
+  titleNode.innerHTML = '';
+  titleNode.appendChild(document.createTextNode(title));
   document.querySelector('#u').innerHTML = url;
 
   document.body.addEventListener('click', () => {


### PR DESCRIPTION
Setting `innerHTML` directly can result in accidental HTML injection (see issue #105). Instead, we use `createTextNode`, which escapes all special characters.